### PR TITLE
Add dask-gateway to image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 
   # Jupyter + Dask for interactive computing
   - dask~=2021.8
+  - dask-gateway~=0.9
   - dask-labextension~=5.1
   - jupyterlab>=3.1,<3.1.5
   - jupyter-offlinenotebook~=0.2


### PR DESCRIPTION
This image is used by the catalyst coop hub used by 2i2c, and we are now starting
to automatically test the hubs on each change. As dask-gateway functionality is
available for this hub, we test it too - but as the `dask-gateway` package isn't
installed in the image, it fails! This PR adds `dask-gateway` to the image, and
will help keep our infra more stable.

Fixes https://github.com/2i2c-org/infrastructure/issues/797