### PR TITLE
Add SEC 10-k example notebook

### DIFF
--- a/07-sec10k-use-cases.ipynb
+++ b/07-sec10k-use-cases.ipynb
@@ -9,7 +9,12 @@
     "\n",
     "Utilities are often part of a nested hierarchy of holding companies and subsidiaries which makes it difficult to understand the complex web of political and economic incentives that inform these companies' behavior.\n",
     "Subsidiary relationships are reported in the SEC’s Form 10-K, along with other useful information about each company.\n",
-    "PUDL has extracted a beta version of several tables of corporation data from the SEC Form 10-K and its attachments, including a conservative set of links likely to exist between SEC-identified entities and those from FERC and the EIA.\n",
+    "\n",
+    "The Public Utility Data Liberation project (PUDL) has extracted a beta version of several tables of corporation data from the SEC Form 10-K and its attachments, including a conservative set of links likely to exist between SEC-identified entities and those from FERC and the EIA. We will explore some of the resulting data in this notebook, but for more information, see:\n",
+    "\n",
+    "* [Documentation for the SEC 10-K dataset in PUDL](https://catalystcoop-pudl.readthedocs.io/en/latest/data_sources/sec10k.html)\n",
+    "* [Methodology for how we extracted ownership data from SEC 10-K Exhibit 21](https://catalystcoop-pudl.readthedocs.io/en/latest/methodology/sec10k_modeling.html)\n",
+    "\n",
     "Four output tables are available:\n",
     "\n",
     "* `out_sec10k__quarterly_filings`: information about the Form 10-K filings themselves (filing date, subversion of the 10-K used, source URL, etc)\n",
@@ -22,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "db5e8e4e-84c4-4afe-ad4f-1f91c308204c",
    "metadata": {},
    "outputs": [],
@@ -32,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "baefb4cd-b1dc-4912-bc2e-c875adf30eea",
    "metadata": {},
    "outputs": [],
@@ -65,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "0218d9e0-9850-41e8-bc9f-0d85338285da",
    "metadata": {},
    "outputs": [
@@ -161,7 +166,7 @@
        "5                 valaris ltd  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,50 +192,7 @@
    "id": "e6e99927-3f13-443b-a4f8-709f06231eca",
    "metadata": {},
    "source": [
-    "Before October, 1987, _Valaris_ was known as _Blocker Energy Corporation_. From then to July 1992, they were _Energy Service Company, Incorporated_. Periodic name changes continued; the company has been _Valaris, Limited_ since August 2019.\n",
-    "\n",
-    "If we just want a list of all the names they've ever used so that we can keyword-search in other datasets, we can do some data frame arithmetic to combine the two name columns and deduplicate them into a file:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "0371ca62-7e6c-4630-8ca5-c15c2d3840f6",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "central_index_key,names\n",
-      "0000314808,blocker energy corp|energy service company inc|ensco international inc|ensco international plc|ensco rowan plc|valaris ltd|valaris plc\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\n",
-    "    valaris_names.drop(columns=\"name_change_date\")\n",
-    "    .set_index(\"central_index_key\")\n",
-    "    # put all the names in a single column\n",
-    "    .stack()\n",
-    "    .drop(index=\"level_1\")\n",
-    "    .groupby(\"central_index_key\")\n",
-    "    # join unique names together, |-delimited\n",
-    "    .agg(lambda x: \"|\".join(sorted(set(x))))\n",
-    "    # format for output\n",
-    "    .reset_index()\n",
-    "    .rename(columns={0:\"names\"})\n",
-    "    .to_csv(index=False)\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6ca8d171-e730-47e4-a78e-22bb0381c162",
-   "metadata": {},
-   "source": [
-    "This method and format would be suitable for compiling historical names of many different corporations into a single file, which could then be used as input to some future process downstream."
+    "Before October, 1987, _Valaris_ was known as _Blocker Energy Corporation_. From then to July 1992, they were _Energy Service Company, Incorporated_. Periodic name changes continued; the company has been _Valaris, Limited_ since August 2019."
    ]
   },
   {
@@ -251,13 +213,14 @@
   {
    "cell_type": "markdown",
    "id": "2d6fb3f6-272a-463b-9ceb-4e68042a9e57",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Use SIC codes to evaluate the performance of PUDL record linkages between SEC and EIA\n",
     "\n",
-    "The SEC 10-K does not include EIA or FERC utility ids. PUDL uses a statistical model to conservatively predict linkages between corporations in the SEC 10-K data and their counterparts in the EIA data.\n",
+    "The SEC 10-K does not include EIA or FERC utility ids.\n",
+    "PUDL uses a statistical model to conservatively predict linkages between corporations in the SEC 10-K data and their counterparts in the EIA data.\n",
+    "For more on how we do that, see [our methodology page](https://catalystcoop-pudl.readthedocs.io/en/latest/methodology/sec10k_modeling.html).\n",
+    "\n",
     "We want to evaluate the performance of this model (are the links any good?), but we don't want to manually examine each of the thousands of links.\n",
     "Instead, we can use industry codes to compute some summary statistics that can help us decide whether the links roughly make sense as a whole:\n",
     "\n",
@@ -268,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "81b30668-84db-4ffe-b778-c68224fb0593",
    "metadata": {
     "scrolled": true
@@ -279,28 +242,24 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 28,
-   "id": "7453c638-e7d6-4594-b415-8e12aa7fde44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import polars as pl\n",
-    "pl_company_quarters = pl.read_parquet(\n",
-    "    s3(\"out_sec10k__quarterly_company_information\"),\n",
-    "    storage_options={\n",
-    "        \"skip_signature\": \"true\",\n",
-    "        \"region\": \"us-west-2\",\n",
-    "    },\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "351a8010-4139-4248-a4e9-7b52f391cd4f",
    "metadata": {},
    "source": [
-    "#### What industries have the highest representation among record linkages?"
+    "#### What industries have the highest representation among record linkages?\n",
+    "\n",
+    "To determine which industries have the greatest number of links, we need to find out:\n",
+    "\n",
+    "* The total number of quarterly records with a link between the SEC filer and an EIA utility ID\n",
+    "* How many times each industry code occurs among those records\n",
+    "\n",
+    "This will be slightly complicated by the following:\n",
+    "\n",
+    "* Not all quarterly records include industry information\n",
+    "* A single company may file many quarterly records, so the distribution of industries across quarterly records may differ from the distribution of industries across companies\n",
+    "* A single company may file with different industry codes in different quarters\n",
+    "\n",
+    "...but we can account for those factors in our analysis if we are careful. Let's begin."
    ]
   },
   {
@@ -313,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "990e48f5-3d89-42f5-a4d5-a7d3e6a3db91",
    "metadata": {},
    "outputs": [
@@ -323,7 +282,7 @@
        "15178"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -343,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "id": "8550f5a6-2e18-418e-9063-c59180def107",
    "metadata": {},
    "outputs": [
@@ -353,7 +312,7 @@
        "529"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -375,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "9e259a83-b294-479c-a822-e7723ef58115",
    "metadata": {},
    "outputs": [
@@ -385,7 +344,7 @@
        "15133"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -406,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "id": "91541af1-9f11-45af-bd72-7386b23041eb",
    "metadata": {},
    "outputs": [
@@ -416,7 +375,7 @@
        "526"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,12 +396,12 @@
    "source": [
     "Do companies sometimes change their industry code across filings?\n",
     "\n",
-    "/is the number of unique (company, industry) pairs greater than the number of unique companies?"
+    "In other words, is the number of unique (company, industry) pairs greater than the number of unique companies?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "id": "80230df1-3c50-414f-9362-c01a5b4fc75f",
    "metadata": {},
    "outputs": [
@@ -452,7 +411,7 @@
        "632"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -468,12 +427,12 @@
    "source": [
     "Among quarterly records with a link between the filer and an EIA utility company, as well as a valid SIC code, what industries are most commonly seen?\n",
     "\n",
-    "/which industries hold the greatest percentage of available links?"
+    "In other words, which industries hold the greatest percentage of available links?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "id": "070b1ab8-5aab-4b79-a77a-91586c74d60b",
    "metadata": {},
    "outputs": [
@@ -605,7 +564,7 @@
        "9             124           0.008194  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -636,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "id": "160470a0-dbf3-4cfd-9e3e-b38cd02a47cb",
    "metadata": {},
    "outputs": [
@@ -768,7 +727,7 @@
        "9              10           0.015924  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -795,7 +754,7 @@
    "id": "75c3983d-7bc1-4e22-b7bb-3e9fee5101e3",
    "metadata": {},
    "source": [
-    "lol, \"blank checks\"[<sup id=\"fn1-back\">1</sup>](#fn1 \"https://en.wikipedia.org/wiki/Special-purpose_acquisition_company\") -- but otherwise pretty close to the distribution over all quarterly links.\n",
+    "With the exception of \"blank checks\"[<sup id=\"fn1-back\">1</sup>](#fn1 \"https://en.wikipedia.org/wiki/Special-purpose_acquisition_company\")  this list is pretty close to the distribution over all quarterly links.\n",
     "\n",
     "[<sup id=\"fn1\">1</sup>](#fn1-back) https://en.wikipedia.org/wiki/Special-purpose_acquisition_company"
    ]
@@ -815,12 +774,12 @@
    "source": [
     "Among quarterly records with a valid SIC code, and with or without links to an EIA utility, which industries have the greatest link coverage?\n",
     "\n",
-    "/which industries have the fewest unlinked records?"
+    "In other words, which industries have the lowest percentage of unlinked records?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "id": "b1feb9c0-7035-44f9-a56d-7b00f41b3abf",
    "metadata": {},
    "outputs": [
@@ -952,7 +911,7 @@
        "9              153.0                  0.228758  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -987,7 +946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "id": "d1e1508f-12be-4264-91e4-4f556f3774d1",
    "metadata": {},
    "outputs": [
@@ -1119,7 +1078,7 @@
        "9                7.0                  0.142857  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1150,9 +1109,7 @@
    "id": "89d85606-2c7d-48d2-bc17-e0de02139e8c",
    "metadata": {},
    "source": [
-    "This change is more significant: in the top 10 industries we still see electric services and paper, but there's no more tires, space vehicles, or furniture, and we've added gas. The overall proportion of each SIC which is linked has also dropped: the majority of _quarterly records_ for 4911 Electric Services have links to EIA utilities, but a _minority_ of unique companies associated with this industry are linked.\n",
-    "\n",
-    "TODO: conclusions"
+    "This change is more significant: in the top 10 industries we still see electric services and paper, but there's no more tires, space vehicles, or furniture, and we've added gas. The overall proportion of each SIC which is linked has also dropped: the majority of _quarterly records_ for 4911 Electric Services have links to EIA utilities, but a _minority_ of unique companies associated with this industry are linked."
    ]
   },
   {
@@ -1172,16 +1129,14 @@
   {
    "cell_type": "markdown",
    "id": "3d910400-cd1e-4eef-b10e-02f12123c47d",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Within industries we most associate with electric utilities, what percent of SEC filers have links to an EIA utility ID?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 15,
    "id": "0ba542a4-80f6-492a-b109-e6e024d455c9",
    "metadata": {},
    "outputs": [
@@ -1265,7 +1220,7 @@
        "4991            cogeneration services & small power producers                      28  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1293,9 +1248,7 @@
   {
    "cell_type": "markdown",
    "id": "4b3f22a9-4f22-4be3-89f7-30b085c170ed",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### What are some typical companies in these industries that have not been linked to an EIA utility id?"
    ]
@@ -1310,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 16,
    "id": "1dad22dd-9948-4759-ae64-1d609cc8d25d",
    "metadata": {
     "scrolled": true
@@ -1777,7 +1730,7 @@
        "[10 rows x 29 columns]"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1812,18 +1765,18 @@
   {
    "cell_type": "markdown",
    "id": "0df361c8-a73e-4738-b8f9-6e03b3eaac59",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Could we manually find these in EIA if we needed to?\n",
     "\n",
-    "Let's look at Connecticut Light & Power Co. The SEC data has it located in Berlin, CT:"
+    "Let's look at Connecticut Light & Power Co. \n",
+    "The information we have from the SEC about this company that we'll be able to use to manually search for a corresponding record in the EIA utility data is the company name and location. \n",
+    "The SEC has Connecticut Light & Power Co. located in Berlin, CT:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 17,
    "id": "9dbf54dc-e40d-488c-9f41-9b7ba308a5ba",
    "metadata": {},
    "outputs": [
@@ -1974,7 +1927,7 @@
        "mail_zip_code                                                [<NA>, 06037]"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1993,28 +1946,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 20,
    "id": "113342d7-06fc-4767-b1ae-0cd94343f65e",
    "metadata": {},
    "outputs": [],
    "source": [
     "eia_utilities = pd.read_parquet(s3(\"out_eia__yearly_utilities\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "id": "35c4f36e-44dd-4dcb-bdcd-e620bc173208",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pl_eia_utilities = pl.read_parquet(\n",
-    "    s3(\"out_eia__yearly_utilities\"),\n",
-    "    storage_options={\n",
-    "        \"skip_signature\": \"true\",\n",
-    "        \"region\": \"us-west-2\",\n",
-    "    },\n",
-    ")"
    ]
   },
   {
@@ -2024,12 +1961,16 @@
    "source": [
     "Then look for utilities with a name that starts with \"Connecticut Light\".\n",
     "\n",
-    "We'll also grab any utilities located in Berlin, CT."
+    "We'll also grab any utilities located in Berlin, CT.\n",
+    "\n",
+    "Electric utilities may change names from time to time, but they change locations much more rarely.\n",
+    "Two utility companies in the same city with the same name are almost certainly the same company.\n",
+    "Two utility companies in the same city, with different names, but in different years, have a decent chance of being the same company -- especially if we can find other corroborating information linking them."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 21,
    "id": "a73cf5b5-57ec-424a-90b0-ce6b0f2ccd57",
    "metadata": {
     "scrolled": true
@@ -2056,11 +1997,11 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>151997</th>\n",
-       "      <th>151991</th>\n",
-       "      <th>122134</th>\n",
-       "      <th>122133</th>\n",
-       "      <th>104366</th>\n",
+       "      <th>152021</th>\n",
+       "      <th>152015</th>\n",
+       "      <th>122158</th>\n",
+       "      <th>122157</th>\n",
+       "      <th>104390</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2084,8 +2025,8 @@
        "      <th>utility_name_eia</th>\n",
        "      <td>Connecticut Light &amp; Power Co</td>\n",
        "      <td>Connecticut Light &amp; Power Co</td>\n",
-       "      <td>Northeast Generation Services</td>\n",
-       "      <td>Northeast Generation Services</td>\n",
+       "      <td>Northeast Generation Services Company</td>\n",
+       "      <td>Northeast Generation Services Company</td>\n",
        "      <td>Eversource Energy</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -2285,7 +2226,7 @@
        "</div>"
       ],
       "text/plain": [
-       "                                                          151997  \\\n",
+       "                                                          152021  \\\n",
        "utility_id_eia                                              4176   \n",
        "utility_id_pudl                                               75   \n",
        "utility_name_eia                    Connecticut Light & Power Co   \n",
@@ -2314,7 +2255,7 @@
        "phone_extension_2                                           3412   \n",
        "data_maturity                                              final   \n",
        "\n",
-       "                                                            151991  \\\n",
+       "                                                            152015  \\\n",
        "utility_id_eia                                                4176   \n",
        "utility_id_pudl                                                 75   \n",
        "utility_name_eia                      Connecticut Light & Power Co   \n",
@@ -2343,65 +2284,65 @@
        "phone_extension_2                                             <NA>   \n",
        "data_maturity                                                final   \n",
        "\n",
-       "                                                           122134  \\\n",
-       "utility_id_eia                                              29868   \n",
-       "utility_id_pudl                                              4423   \n",
-       "utility_name_eia                    Northeast Generation Services   \n",
-       "report_date                                            2010-01-01   \n",
-       "street_address                                               <NA>   \n",
-       "city                                                       Berlin   \n",
-       "state                                                          CT   \n",
-       "zip_code                                                    06037   \n",
-       "plants_reported_owner                                        <NA>   \n",
-       "plants_reported_operator                                     <NA>   \n",
-       "plants_reported_asset_manager                                <NA>   \n",
-       "plants_reported_other_relationship                           <NA>   \n",
-       "entity_type                                                  <NA>   \n",
-       "attention_line                                               <NA>   \n",
-       "address_2                                       107 Selden Street   \n",
-       "zip_code_4                                                   <NA>   \n",
-       "contact_firstname                                            <NA>   \n",
-       "contact_lastname                                             <NA>   \n",
-       "contact_title                                                <NA>   \n",
-       "phone_number                                                 <NA>   \n",
-       "phone_extension                                              <NA>   \n",
-       "contact_firstname_2                                          <NA>   \n",
-       "contact_lastname_2                                           <NA>   \n",
-       "contact_title_2                                              <NA>   \n",
-       "phone_number_2                                               <NA>   \n",
-       "phone_extension_2                                            <NA>   \n",
-       "data_maturity                                               final   \n",
+       "                                                                   122158  \\\n",
+       "utility_id_eia                                                      29868   \n",
+       "utility_id_pudl                                                      4423   \n",
+       "utility_name_eia                    Northeast Generation Services Company   \n",
+       "report_date                                                    2010-01-01   \n",
+       "street_address                                                       <NA>   \n",
+       "city                                                               Berlin   \n",
+       "state                                                                  CT   \n",
+       "zip_code                                                            06037   \n",
+       "plants_reported_owner                                                <NA>   \n",
+       "plants_reported_operator                                             <NA>   \n",
+       "plants_reported_asset_manager                                        <NA>   \n",
+       "plants_reported_other_relationship                                   <NA>   \n",
+       "entity_type                                                          <NA>   \n",
+       "attention_line                                                       <NA>   \n",
+       "address_2                                               107 Selden Street   \n",
+       "zip_code_4                                                           <NA>   \n",
+       "contact_firstname                                                    <NA>   \n",
+       "contact_lastname                                                     <NA>   \n",
+       "contact_title                                                        <NA>   \n",
+       "phone_number                                                         <NA>   \n",
+       "phone_extension                                                      <NA>   \n",
+       "contact_firstname_2                                                  <NA>   \n",
+       "contact_lastname_2                                                   <NA>   \n",
+       "contact_title_2                                                      <NA>   \n",
+       "phone_number_2                                                       <NA>   \n",
+       "phone_extension_2                                                    <NA>   \n",
+       "data_maturity                                                       final   \n",
        "\n",
-       "                                                           122133  \\\n",
-       "utility_id_eia                                              29868   \n",
-       "utility_id_pudl                                              4423   \n",
-       "utility_name_eia                    Northeast Generation Services   \n",
-       "report_date                                            2011-01-01   \n",
-       "street_address                                  107 Selden Street   \n",
-       "city                                                       Berlin   \n",
-       "state                                                          CT   \n",
-       "zip_code                                                    06037   \n",
-       "plants_reported_owner                                        <NA>   \n",
-       "plants_reported_operator                                     <NA>   \n",
-       "plants_reported_asset_manager                                <NA>   \n",
-       "plants_reported_other_relationship                           <NA>   \n",
-       "entity_type                                                  <NA>   \n",
-       "attention_line                                               <NA>   \n",
-       "address_2                                                    <NA>   \n",
-       "zip_code_4                                                   <NA>   \n",
-       "contact_firstname                                            <NA>   \n",
-       "contact_lastname                                             <NA>   \n",
-       "contact_title                                                <NA>   \n",
-       "phone_number                                                 <NA>   \n",
-       "phone_extension                                              <NA>   \n",
-       "contact_firstname_2                                          <NA>   \n",
-       "contact_lastname_2                                           <NA>   \n",
-       "contact_title_2                                              <NA>   \n",
-       "phone_number_2                                               <NA>   \n",
-       "phone_extension_2                                            <NA>   \n",
-       "data_maturity                                               final   \n",
+       "                                                                   122157  \\\n",
+       "utility_id_eia                                                      29868   \n",
+       "utility_id_pudl                                                      4423   \n",
+       "utility_name_eia                    Northeast Generation Services Company   \n",
+       "report_date                                                    2011-01-01   \n",
+       "street_address                                          107 Selden Street   \n",
+       "city                                                               Berlin   \n",
+       "state                                                                  CT   \n",
+       "zip_code                                                            06037   \n",
+       "plants_reported_owner                                                <NA>   \n",
+       "plants_reported_operator                                             <NA>   \n",
+       "plants_reported_asset_manager                                        <NA>   \n",
+       "plants_reported_other_relationship                                   <NA>   \n",
+       "entity_type                                                          <NA>   \n",
+       "attention_line                                                       <NA>   \n",
+       "address_2                                                            <NA>   \n",
+       "zip_code_4                                                           <NA>   \n",
+       "contact_firstname                                                    <NA>   \n",
+       "contact_lastname                                                     <NA>   \n",
+       "contact_title                                                        <NA>   \n",
+       "phone_number                                                         <NA>   \n",
+       "phone_extension                                                      <NA>   \n",
+       "contact_firstname_2                                                  <NA>   \n",
+       "contact_lastname_2                                                   <NA>   \n",
+       "contact_title_2                                                      <NA>   \n",
+       "phone_number_2                                                       <NA>   \n",
+       "phone_extension_2                                                    <NA>   \n",
+       "data_maturity                                                       final   \n",
        "\n",
-       "                                               104366  \n",
+       "                                               104390  \n",
        "utility_id_eia                                  64810  \n",
        "utility_id_pudl                                 13966  \n",
        "utility_name_eia                    Eversource Energy  \n",
@@ -2431,7 +2372,7 @@
        "data_maturity                                    <NA>  "
       ]
      },
-     "execution_count": 95,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2462,7 +2403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 22,
    "id": "b77e9163-eb1f-4198-8003-b0d39af41d32",
    "metadata": {},
    "outputs": [
@@ -2504,7 +2445,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2537,7 +2478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 23,
    "id": "3947ee1c-be9c-4fcd-84bc-08f2615e17eb",
    "metadata": {},
    "outputs": [
@@ -2679,7 +2620,7 @@
        "mail_zip_code_4                                                       1616"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2711,23 +2652,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
-   "id": "fa99a73a-374c-4869-9616-6bac9a24c60c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "subs = pd.read_parquet(\n",
-    "    s3(\"out_sec10k__parents_and_subsidiaries\"),\n",
-    "    dtype_backend=\"pyarrow\",\n",
-    "    engine=\"pyarrow\",\n",
-    "    filters=[(\"parent_company_central_index_key\",\"=\",\"0000072741\")],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 98,
-   "id": "2ff5e110-c801-418b-896b-a0bcca016119",
+   "execution_count": 24,
+   "id": "f8dd3795-ac1b-43ac-b800-8f6289aa50eb",
    "metadata": {},
    "outputs": [
     {
@@ -2946,12 +2872,19 @@
        "[4 rows x 48 columns]"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "subs = pd.read_parquet(\n",
+    "    s3(\"out_sec10k__parents_and_subsidiaries\"),\n",
+    "    dtype_backend=\"pyarrow\",\n",
+    "    engine=\"pyarrow\",\n",
+    "    filters=[(\"parent_company_central_index_key\",\"=\",\"0000072741\")],\n",
+    ")\n",
+    "\n",
     "subs.loc[\n",
     "    subs.subsidiary_company_central_index_key==\"0000023426\"\n",
     "]"
@@ -3006,7 +2939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 25,
    "id": "5d3570de-1e14-4ce7-a9d5-cd5f4e0c40d6",
    "metadata": {
     "scrolled": true
@@ -3020,7 +2953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 26,
    "id": "d8441b86-1b3d-4a55-b036-700c00b3a67a",
    "metadata": {
     "scrolled": true
@@ -3159,7 +3092,7 @@
        "1037   10435 downsville pike  hagerstown         MD  10435 downsville pike  "
       ]
      },
-     "execution_count": 135,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3199,7 +3132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 27,
    "id": "5c919493-2c64-4146-9862-d233ba6d78c4",
    "metadata": {},
    "outputs": [
@@ -3336,7 +3269,7 @@
        "570  birmingham         AL                2101 6th avenue north  "
       ]
      },
-     "execution_count": 134,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3354,45 +3287,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31081288-d9d1-400d-9b98-f28562b29950",
-   "metadata": {},
-   "source": [
-    "### Fuel\n",
-    "\n",
-    "Do we mean extraction?\n",
-    "\n",
-    "* 1311:\tOffice of Energy & Transportation; CRUDE PETROLEUM & NATURAL GAS\n",
-    "* 1381:\tOffice of Energy & Transportation; \tDRILLING OIL & GAS WELLS\n",
-    "* 1382:\tOffice of Energy & Transportation; \tOIL & GAS FIELD EXPLORATION SERVICES\n",
-    "* 1389:\tOffice of Energy & Transportation; \tOIL & GAS FIELD SERVICES, NEC\n",
-    "* 3533:\tOffice of Energy & Transportation; \tOIL & GAS FIELD MACHINERY & EQUIPMENT\n",
-    "\n",
-    "Or refining?\n",
-    "\n",
-    "* 2911:\tOffice of Energy & Transportation; \tPETROLEUM REFINING\n",
-    "* 2990:\tOffice of Energy & Transportation; \tMISCELLANEOUS PRODUCTS OF PETROLEUM & COAL\n",
-    "\n",
-    "Or wholesale?\n",
-    "\n",
-    "* 5171:\tOffice of Trade & Services; \tWHOLESALE-PETROLEUM BULK STATIONS & TERMINALS\n",
-    "* 5172:\tOffice of Trade & Services; \tWHOLESALE-PETROLEUM & PETROLEUM PRODUCTS (NO BULK STATIONS)\n",
-    "\n",
-    "Or coal?\n",
-    "\n",
-    "* 1220:\tOffice of Energy & Transportation; \tBITUMINOUS COAL & LIGNITE MINING\n",
-    "* 1221:\tOffice of Energy & Transportation; \tBITUMINOUS COAL & LIGNITE SURFACE MINING"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ef7b308-7fb9-4feb-86df-d1fb2c8418d1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
    "id": "9694af95-b3c6-482d-b341-470eb6036d53",
    "metadata": {},
    "source": [
@@ -3407,7 +3301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 29,
    "id": "2521825e-44c9-4739-a930-776cf2465e79",
    "metadata": {},
    "outputs": [
@@ -3417,13 +3311,15 @@
      "text": [
       "150505 subsidiaries of companies in electricity industries\n",
       "  5023 subsidiaries where SIC is known\n",
-      " 13436 subsidiaries with unknown SIC known to be an EIA utility\n",
-      "132046 subsidiaries with insufficient industry metadata to decide either way\n",
+      " 14019 subsidiaries with unknown SIC known to be an EIA utility\n",
+      "131463 subsidiaries with insufficient industry metadata to decide either way\n",
       "    65 subsidiaries where SIC is not an electricity industry\n"
      ]
     }
    ],
    "source": [
+    "out_sec10k__parents_and_subsidiaries = pd.read_parquet(s3(\"out_sec10k__parents_and_subsidiaries\"))\n",
+    "\n",
     "sec_electricity_ciks = sec_electricity[[\"central_index_key\"]].drop_duplicates()\n",
     "\n",
     "# cross-industry relationships where an electricity company owns a company in another industry\n",
@@ -3473,7 +3369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 30,
    "id": "5aa3a4da-b105-4f7b-a978-bb030f60782f",
    "metadata": {},
    "outputs": [
@@ -3495,7 +3391,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 159,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3516,7 +3412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 31,
    "id": "a31fae11-b3d6-4d52-ab7c-fcf3d956b73e",
    "metadata": {},
    "outputs": [
@@ -3578,7 +3474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 32,
    "id": "b794ca8a-dbe1-4fac-b73d-35b5c1f9bb93",
    "metadata": {
     "scrolled": true
@@ -3619,7 +3515,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 160,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3633,23 +3529,15 @@
    "id": "839340eb-252e-486d-9330-66adf8065f14",
    "metadata": {},
    "source": [
-    "# Leverage Subsidiary Relationships"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "825fa6f7-7e88-4396-80d0-222b0f743bc0",
-   "metadata": {},
-   "source": [
-    "## Find all historical subsidiaries of a company"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "04d1297b-ed9b-477d-941b-bf7b40693c6b",
-   "metadata": {},
-   "source": [
-    "## Working with multiple layers of subsidiary nesting"
+    "# Next steps\n",
+    "\n",
+    "Another narrative we'd like to explore in a future version of this notebook is about leveraging subsidiary information.\n",
+    "Possible topics include:\n",
+    "\n",
+    "* Finding all historical subsidiaries of a company\n",
+    "* Working with multiple layers of subsidiary nesting\n",
+    "\n",
+    "If these interest you, get in touch!"
    ]
   }
  ],


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Implement [the sec10k notebook spec from October 2025](https://docs.google.com/document/d/17Y_KqiHang1wqsvZeErLFJO0zRMggvw8BVXKMNyARps/edit?tab=t.0#heading=h.ccqvi9rry8dm)

What problem does this address?

What did you change in this PR?

* Add example notebook for SEC 10-k

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

Easy

- [x] Link to our sec10k docs in the intro
- [x] Confirm beta status or not
- [x] Spell out PUDL at first usage and link to main docs index
- [x] Cut "make file output of namechanges we can use at unspecified future time"
- [x] link to Methods when we first mention matching to EIA
- [x] drop rogue polars section
- [x] clarify why location is important to matching
- [x] Cut fuel section
- [x] expand slash notation to "in other words" "put another way"
- [x] Add conclusions / drop TODO for unique link coverage

Needs discussion / future work

- [ ] connect output tables to the (which?) eia table
- [ ] cut coverage sections? & if so, find a way to keep the cool part (about how prevalent "blank checks" industries are in the electricity generation space)?
- [ ] motivate natural gas
- [ ] annotate subsets of subsidiaries with percentages (but out of what population?)
- [ ] drop counts 2 or less, even though the sample size is already small?
- [ ] find a good example of a utility whose parent or subsidiary is something that has generated clearly biasing interests and caused a scandal

