### PR TITLE
Add pyarrow import to utility explorer, needed for wasm

### DIFF
--- a/wasm/marimo/utility-explorer.py
+++ b/wasm/marimo/utility-explorer.py
@@ -21,14 +21,12 @@ def _():
     import json
     from urllib.request import urlopen
 
-    # import plotly.graph_objects as go
-    # import plotly
     import altair as alt
     import pandas as pd
+    import pyarrow as pa
 
     import marimo as mo
 
-    # import plotly.express as px
     return alt, json, mo, pd, urlopen
 
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?

Runs in marimo editor but not in wasm

What did you change in this PR?

Add pyarrow import so wasm can read parquets

# Testing

How did you make sure this worked? How can a reviewer verify this?

Ran locally via `pixi run -e wasm export-wasm-marimo --serve`

